### PR TITLE
Return Zero Clamp Size

### DIFF
--- a/modules/ChatFrames.lua
+++ b/modules/ChatFrames.lua
@@ -235,9 +235,11 @@ end
   function mod:FloatingChatFrame_UpdateBackgroundAnchors(frame)
     if self.db.profile.removeclamp then
       frame:SetClampRectInsets(0, 0, 0, 0)
-    	if frame:GetName() == "ChatFrame1" then
-		    frame:SetClampedToScreen(false)
-	    end
+      if not Prat.IsClassic then
+    	  if frame:GetName() == "ChatFrame1" then
+		      frame:SetClampedToScreen(false)
+	      end
+      end
     end
     Prat.Frames[frame:GetName()] = frame
     local m = Prat.Addon:GetModule("Font", true)
@@ -246,9 +248,11 @@ end
   function mod:FCF_DockFrame(frame, ...)
     if self.db.profile.removeclamp then
       frame:SetClampRectInsets(0, 0, 0, 0)
-    	if frame:GetName() == "ChatFrame1" then
-		    frame:SetClampedToScreen(false)
-	    end
+      if not Prat.IsClassic then
+    	  if frame:GetName() == "ChatFrame1" then
+		      frame:SetClampedToScreen(false)
+	      end
+      end
     end
     Prat.Frames[frame:GetName()] = frame
     local m = Prat.Addon:GetModule("Font", true)
@@ -258,9 +262,11 @@ end
   function mod:FCF_UnDockFrame(frame, ...)
     if self.db.profile.removeclamp then
       frame:SetClampRectInsets(0, 0, 0, 0)
-  	  if frame:GetName() == "ChatFrame1" then
-		    frame:SetClampedToScreen(false)
-	    end
+      if not Prat.IsClassic then
+    	  if frame:GetName() == "ChatFrame1" then
+		      frame:SetClampedToScreen(false)
+	      end
+      end
     end
     Prat.Frames[frame:GetName()] = frame
     local m = Prat.Addon:GetModule("Font", true)

--- a/modules/ChatFrames.lua
+++ b/modules/ChatFrames.lua
@@ -235,6 +235,9 @@ end
   function mod:FloatingChatFrame_UpdateBackgroundAnchors(frame)
     if self.db.profile.removeclamp then
       frame:SetClampRectInsets(0, 0, 0, 0)
+    	if frame:GetName() == "ChatFrame1" then
+		    frame:SetClampedToScreen(false)
+	    end
     end
     Prat.Frames[frame:GetName()] = frame
     local m = Prat.Addon:GetModule("Font", true)
@@ -243,6 +246,9 @@ end
   function mod:FCF_DockFrame(frame, ...)
     if self.db.profile.removeclamp then
       frame:SetClampRectInsets(0, 0, 0, 0)
+    	if frame:GetName() == "ChatFrame1" then
+		    frame:SetClampedToScreen(false)
+	    end
     end
     Prat.Frames[frame:GetName()] = frame
     local m = Prat.Addon:GetModule("Font", true)
@@ -252,6 +258,9 @@ end
   function mod:FCF_UnDockFrame(frame, ...)
     if self.db.profile.removeclamp then
       frame:SetClampRectInsets(0, 0, 0, 0)
+  	  if frame:GetName() == "ChatFrame1" then
+		    frame:SetClampedToScreen(false)
+	    end
     end
     Prat.Frames[frame:GetName()] = frame
     local m = Prat.Addon:GetModule("Font", true)

--- a/modules/ChatFrames.lua
+++ b/modules/ChatFrames.lua
@@ -235,11 +235,6 @@ end
   function mod:FloatingChatFrame_UpdateBackgroundAnchors(frame)
     if self.db.profile.removeclamp then
       frame:SetClampRectInsets(0, 0, 0, 0)
-      if not Prat.IsClassic then
-    	  if frame:GetName() == "ChatFrame1" then
-		      frame:SetClampedToScreen(false)
-	      end
-      end
     end
     Prat.Frames[frame:GetName()] = frame
     local m = Prat.Addon:GetModule("Font", true)
@@ -248,11 +243,6 @@ end
   function mod:FCF_DockFrame(frame, ...)
     if self.db.profile.removeclamp then
       frame:SetClampRectInsets(0, 0, 0, 0)
-      if not Prat.IsClassic then
-    	  if frame:GetName() == "ChatFrame1" then
-		      frame:SetClampedToScreen(false)
-	      end
-      end
     end
     Prat.Frames[frame:GetName()] = frame
     local m = Prat.Addon:GetModule("Font", true)
@@ -262,11 +252,6 @@ end
   function mod:FCF_UnDockFrame(frame, ...)
     if self.db.profile.removeclamp then
       frame:SetClampRectInsets(0, 0, 0, 0)
-      if not Prat.IsClassic then
-    	  if frame:GetName() == "ChatFrame1" then
-		      frame:SetClampedToScreen(false)
-	      end
-      end
     end
     Prat.Frames[frame:GetName()] = frame
     local m = Prat.Addon:GetModule("Font", true)
@@ -326,6 +311,11 @@ end
 
       if prof.removeclamp then
         cf:SetClampRectInsets(0, 0, 0, 0)
+	    	if not Prat.IsClassic then	
+    	    if cf:GetName() == "ChatFrame1" then
+		        cf:SetClampedToScreen(false)
+	        end
+        end  
       end
     else
       minWidth, minHeight = prof.minchatwidthdefault, prof.minchatheightdefault


### PR DESCRIPTION
Allows the main chat window to be moved flush with the screen again by allowing it to be moved outside the screen because blizzards frame boarder in edit mode is larger than the real chat window.