### PR TITLE
Revert "Fix flashing of tabs." to fix Lua error

### DIFF
--- a/modules/ChatTabs.lua
+++ b/modules/ChatTabs.lua
@@ -321,7 +321,6 @@ end
   function module:FCF_StartAlertFlash(this)
     if self.db.profile.disableflash then
       FCF_StopAlertFlash(this)
-      UIFrameFlashStop(this:GetHighlightTexture())
     end
   end
 


### PR DESCRIPTION
This reverts commit de0e7408760d1bdb9c9d175d8b3eaad186837aaf.

`FCF_StartAlertFlash` is passed a chat frame, which doesn't have a `GetHightlightTexture` method and throws an error. `FCFDockOverflowButton_UpdatePulseState` does indeed call `self:GetHighlightTexture()`, but it itself is called with `GENERAL_CHAT_DOCK.overflowButton`, not `this`.

However, I don't think this can actually solve the problem in #47 it was meant to fix. Our call to `FCF_StopAlertFlash` should set `chatTab.alerting = false`, and `FCFDockOverflowButton_UpdatePulseState` should disable flashing again.

Furthermore, LibChatAnims replaces `FCF_Start/StopAlertFlash` so we don't actually call Blizzard flashing functions at all in the first place. The problem in #47 must be caused by some other issue, or a conflicting addon, and it is about chat tabs, not the dock overflow button.