### PR TITLE
Modules player names fix

### DIFF
--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -627,7 +627,7 @@ Prat:AddModuleToLoad(function()
 
     self.NEEDS_INIT = nil
 
-    self:updateGuild(self.db.profile.keeplots)
+    self:updateGuild()
   end
 
 

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -681,6 +681,9 @@ Prat:AddModuleToLoad(function()
         if Name then
           local plr, svr = Name:match("([^%-]+)%-?(.*)")
 
+          -- @TODO: Note that since cross-realm guilds are now a thing, this logic may no longer be correct.
+          -- We can no longer assume that a player name without a server is automatically the same as being on our server.
+          -- In other words, if both Someplayer-ServerA and Someplayer-ServerB are in our guild, and they are different class/level, then this logic would overwrite the info of the first one processed with that of the second.
           self:addName(plr, nil, Class, Level, nil, "GUILD")
           self:addName(plr, svr, Class, Level, nil, "GUILD")
         end

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -380,7 +380,7 @@ Prat:AddModuleToLoad(function()
             return false
           end
 
-          if GetAddOnInfo("LibWho-2.0") then
+          if C_AddOns.GetAddOnInfo("LibWho-2.0") then
             return false
           end
 
@@ -600,12 +600,13 @@ Prat:AddModuleToLoad(function()
     end
   end
 
-  -- This function is a wrapper for the Blizzard GuildRoster function, to account for the differences between Retail and Classic
-  function module:GuildRoster(...)
-    if Prat.IsRetail then
-      return C_GuildInfo.GuildRoster(...)
+  -- This function is a wrapper for the Blizzard GuildRoster function
+  -- All supported builds of WoW should now use C_GuildInfo.GuildRoster()
+  function module.GuildRoster()
+    if C_GuildInfo and C_GuildInfo.GuildRoster then
+      return C_GuildInfo.GuildRoster()
     else
-      return GuildRoster(...)
+      return GuildRoster()
     end
   end
 

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -667,8 +667,8 @@ Prat:AddModuleToLoad(function()
   local GuildRosterIsReady = false
 
   function module:updateGuild(canRequestRosterUpdate)
-    if canRequestRosterUpdate ~= nil then GuildRosterIsReady = canRequestRosterUpdate end
     if IsInGuild() then
+      if canRequestRosterUpdate ~= nil then GuildRosterIsReady = true end
       self.GuildRoster()
       if not GuildRosterIsReady then return end
 
@@ -676,10 +676,14 @@ Prat:AddModuleToLoad(function()
       for i = 1, GetNumGuildMembers() do
         Name, _, _, Level, _, _, _, _, _, _, Class = GetGuildRosterInfo(i)
 
-        local plr, svr = Name:match("([^%-]+)%-?(.*)")
+        -- Despite the safeguards, it's still possible for GetGuildRosterInfo() to return invalid data.
+        -- Add an additional sanity check to make sure name isn't null before proceeding.
+        if Name then
+          local plr, svr = Name:match("([^%-]+)%-?(.*)")
 
-        self:addName(plr, nil, Class, Level, nil, "GUILD")
-        self:addName(plr, svr, Class, Level, nil, "GUILD")
+          self:addName(plr, nil, Class, Level, nil, "GUILD")
+          self:addName(plr, svr, Class, Level, nil, "GUILD")
+        end
       end
     end
   end

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -669,7 +669,7 @@ Prat:AddModuleToLoad(function()
       self.GuildRoster()
 
       local Name, Class, Level, _
-      for i = 1, GetNumGuildMembers(true) do
+      for i = 1, GetNumGuildMembers() do
         Name, _, _, Level, _, _, _, _, _, _, Class = GetGuildRosterInfo(i)
 
         local plr, svr = Name:match("([^%-]+)%-?(.*)")

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -403,7 +403,7 @@ Prat:AddModuleToLoad(function()
       self:SetAltInvite()
     elseif field == "usewho" then
       if b and not LibStub:GetLibrary("LibWho-2.0", true) then
-        LoadAddOn("LibWho-2.0")
+        C_AddOns.LoadAddOn("LibWho-2.0")
       end
       self.wholib = b and LibStub:GetLibrary("LibWho-2.0", true)
       self:updateAll()
@@ -445,7 +445,7 @@ Prat:AddModuleToLoad(function()
 
     if self.db.profile.usewho then
       if not LibStub:GetLibrary("LibWho-2.0", true) then
-        LoadAddOn("LibWho-2.0")
+        C_AddOns.LoadAddOn("LibWho-2.0")
       end
       self.wholib = LibStub:GetLibrary("LibWho-2.0", true)
     end

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -664,10 +664,13 @@ Prat:AddModuleToLoad(function()
   end
 
 
+  local GuildRosterIsReady = false
 
-  function module:updateGuild()
+  function module:updateGuild(canRequestRosterUpdate)
+    if canRequestRosterUpdate ~= nil then GuildRosterIsReady = canRequestRosterUpdate end
     if IsInGuild() then
       self.GuildRoster()
+      if not GuildRosterIsReady then return end
 
       local Name, Class, Level, _
       for i = 1, GetNumGuildMembers() do


### PR DESCRIPTION
This is a set of fixes to both remove the error in #191 and to clean up some of the deprecated functions to match Blizzard's documentation.