### PR TITLE
[Fixes #200] Deprecate GetSpellInfo

### DIFF
--- a/modules/LinkInfoIcons.lua
+++ b/modules/LinkInfoIcons.lua
@@ -334,7 +334,7 @@ end
 
   local function SubInSpellInfo(link)
     local spellID = tonumber(link:match("Hspell:(%d+)"))
-    local icon = select(3, GetSpellInfo(spellID))
+    local icon = select(3, C_Spell.GetSpellInfo(spellID))
 
     local res = link
     if module.db.profile.spell.icon and icon then


### PR DESCRIPTION
The `GetSpellInfo` function has been moved into the `C_Spell` namespace in 11.0.2, this remedies the broken usage. Fixes #200 