### PR TITLE
Add guild member indicator, faction indicator, and guild-only grats option

### DIFF
--- a/modules/Achievements.lua
+++ b/modules/Achievements.lua
@@ -40,7 +40,7 @@ Prat:AddModuleToLoad(function()
 		["showCompletedDate_desc"] = "Show the date you completed the achievement next to the link",
 		["showGratsLink_name"] = "Show grats link",
 		["showGratsLink_desc"] = "Show a clickable link which sends a grats message",
-		["gratsGuildOnly_name"] = "Only show grats link for guild members",
+		["gratsGuildOnly_name"] = "Guild only grats",
 		["gratsGuildOnly_desc"] = "Only show the grats link for guild member achievements",
 		["dontShowAchievements_name"] = "Don't show achievements",
 		["dontShowAchievements_desc"] = "Hide all achievement messages",

--- a/modules/Achievements.lua
+++ b/modules/Achievements.lua
@@ -40,6 +40,8 @@ Prat:AddModuleToLoad(function()
 		["showCompletedDate_desc"] = "Show the date you completed the achievement next to the link",
 		["showGratsLink_name"] = "Show grats link",
 		["showGratsLink_desc"] = "Show a clickable link which sends a grats message",
+		["gratsGuildOnly_name"] = "Only show grats link for guild members",
+		["gratsGuildOnly_desc"] = "Only show the grats link for guild member achievements",
 		["dontShowAchievements_name"] = "Don't show achievements",
 		["dontShowAchievements_desc"] = "Hide all achievement messages",
 		["customGrats_defualt"] = "Grats %s",
@@ -142,6 +144,7 @@ Prat:AddModuleToLoad(function()
 			dontShowAchievements = false,
 			showCompletedDate = true,
 			showGratsLink = false,
+			gratsGuildOnly = false,
 			customGrats = true,
 			customGratsText = PL.customGrats_defualt
 		}
@@ -169,6 +172,15 @@ Prat:AddModuleToLoad(function()
 				desc = PL.showGratsLink_desc,
 				type = "toggle",
 				order = 110
+			},
+			gratsGuildOnly = {
+				name = PL.gratsGuildOnly_name,
+				desc = PL.gratsGuildOnly_desc,
+				type = "toggle",
+				order = 111,
+				disabled = function()
+					return not module.db.profile.showGratsLink
+				end
 			},
 			customGrats = {
 				name = PL.customGrats_name,
@@ -272,6 +284,9 @@ Prat:AddModuleToLoad(function()
 
 	function module:addGrats(name, group, channel, achievementId)
 		if self.db.profile.showGratsLink then
+			if self.db.profile.gratsGuildOnly and Prat.CurrentMessage.CHATTYPE ~= "GUILD_ACHIEVEMENT" then
+				return ""
+			end
 			return " " .. buildGratsLink(name, group, channel, achievementId)
 		end
 

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -624,12 +624,12 @@ Prat:AddModuleToLoad(function()
 
 		-- Fetch faction data via Club API
 		local clubId = C_Club and C_Club.GetGuildClubId and C_Club.GetGuildClubId()
-		if clubId then
+		if clubId and not (issecretvalue and issecretvalue(clubId)) then
 			local members = C_Club.GetClubMembers(clubId)
-			if members then
+			if members and not (issecretvalue and issecretvalue(members)) then
 				for _, memberId in ipairs(members) do
 					local info = C_Club.GetMemberInfo(clubId, memberId)
-					if info and info.name and info.race then
+					if info and info.name and info.race and not (issecretvalue and issecretvalue(info.name)) then
 						local factionInfo = C_CreatureInfo.GetFactionInfo(info.race)
 						if factionInfo then
 							local name = Ambiguate(info.name, "all"):lower()

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -623,13 +623,17 @@ Prat:AddModuleToLoad(function()
 		end
 
 		-- Fetch faction data via Club API
+		-- GetClubMembers and GetMemberInfo are SecretInChatMessagingLockdown,
+		-- and ClubMemberInfo fields (name, race) may also be secret
 		local clubId = C_Club and C_Club.GetGuildClubId and C_Club.GetGuildClubId()
 		if clubId and not (issecretvalue and issecretvalue(clubId)) then
 			local members = C_Club.GetClubMembers(clubId)
 			if members and not (issecretvalue and issecretvalue(members)) then
 				for _, memberId in ipairs(members) do
 					local info = C_Club.GetMemberInfo(clubId, memberId)
-					if info and info.name and info.race and not (issecretvalue and issecretvalue(info.name)) then
+					if info and not (issecretvalue and issecretvalue(info))
+						and info.name and not issecretvalue(info.name)
+						and info.race and not issecretvalue(info.race) then
 						local factionInfo = C_CreatureInfo.GetFactionInfo(info.race)
 						if factionInfo then
 							local name = Ambiguate(info.name, "all"):lower()

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -59,6 +59,8 @@ Prat:AddModuleToLoad(function()
 		["Toggle raid group showing."] = true,
 		["Show Raid Target Icon"] = true,
 		["Toggle showing the raid target icon which is currently on the player."] = true,
+		["Show Guild"] = true,
+		["Toggle guild member showing."] = true,
 		["Use toon name for RealID"] = true,
 
 		-- In the high-cpu pullout
@@ -166,6 +168,7 @@ Prat:AddModuleToLoad(function()
 	module.Classes = {}
 	module.Levels = {}
 	module.Subgroups = {}
+	module.GuildMembers = {}
 
 	local NOP = function()
 		return
@@ -187,6 +190,7 @@ Prat:AddModuleToLoad(function()
 			levelcolor = "DIFFICULTY",
 			subgroup = true,
 			showtargeticon = false,
+			showguild = false,
 			keep = false,
 			keeplots = false,
 			colormode = "CLASS",
@@ -323,6 +327,12 @@ Prat:AddModuleToLoad(function()
 				order = 142,
 				hidden = Prat.IsRetail,
 			},
+			showguild = {
+				name = PL["Show Guild"],
+				desc = PL["Toggle guild member showing."],
+				type = "toggle",
+				order = 143,
+			},
 			tabcomplete = {
 				name = PL["Enable TabComplete"],
 				desc = PL["Toggle tab completion of player names."],
@@ -403,6 +413,8 @@ Prat:AddModuleToLoad(function()
 		Prat.RegisterMessageItem("PLAYERLEVEL", "PREPLAYERDELIM", "before")
 		Prat.RegisterMessageItem("PLAYERGROUP", "POSTPLAYERDELIM", "after")
 		Prat.RegisterMessageItem("PLAYERCLIENTICON", "PLAYERLEVEL", "before")
+		Prat.RegisterMessageItem("PLAYERGUILD", "PREPLAYERDELIM", "before")
+		Prat.RegisterMessageItem("PLAYERGUILDDELIM", "PLAYERGUILD", "before")
 
 		Prat.EnableProcessingForEvent("CHAT_MSG_GUILD_ACHIEVEMENT")
 		Prat.EnableProcessingForEvent("CHAT_MSG_ACHIEVEMENT")
@@ -449,7 +461,8 @@ Prat:AddModuleToLoad(function()
 	local cache = {
 		module.Levels,
 		module.Classes,
-		module.Subgroups
+		module.Subgroups,
+		module.GuildMembers
 	}
 
 	function module:EmptyDataCache()
@@ -581,10 +594,15 @@ Prat:AddModuleToLoad(function()
 	end
 
 	function module:GUILD_ROSTER_UPDATE()
+		wipe(self.GuildMembers)
 		for i = 1, GetNumGuildMembers() do
 			local Name, _, _, Level, _, _, _, _, _, _, Class = GetGuildRosterInfo(i)
 			if Name then
 				local plr, svr = Name:match("([^%-]+)%-?(.*)")
+				self.GuildMembers[plr:lower()] = true
+				if svr and svr:len() > 0 then
+					self.GuildMembers[(plr .. "-" .. svr):lower()] = true
+				end
 				self:addName(plr, nil, Class, Level, nil, "GUILD")
 				self:addName(plr, svr, Class, Level, nil, "GUILD")
 			end
@@ -828,6 +846,15 @@ Prat:AddModuleToLoad(function()
 		if level and self.db.profile.level then
 			message.PLAYERLEVEL = CLR:Level(tostring(level), level, Name, class)
 			message.PREPLAYERDELIM = ":"
+		end
+
+		-- Add guild indicator if needed
+		if self.db.profile.showguild and self.GuildMembers[Name:lower()] then
+			message.PLAYERGUILD = CLR:Colorize("40ff40", "G")
+			message.PREPLAYERDELIM = ":"
+			if level and self.db.profile.level then
+				message.PLAYERGUILDDELIM = ":"
+			end
 		end
 
 		-- Add raid subgroup information if needed

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -61,6 +61,8 @@ Prat:AddModuleToLoad(function()
 		["Toggle showing the raid target icon which is currently on the player."] = true,
 		["Mark Guildies"] = true,
 		["Toggle showing an indicator for your guild members."] = true,
+		["Show Faction"] = true,
+		["Toggle showing a faction indicator for your guild members."] = true,
 		["Use toon name for RealID"] = true,
 
 		-- In the high-cpu pullout
@@ -169,6 +171,7 @@ Prat:AddModuleToLoad(function()
 	module.Levels = {}
 	module.Subgroups = {}
 	module.GuildMembers = {}
+	module.GuildFactions = {}
 
 	local NOP = function()
 		return
@@ -191,6 +194,7 @@ Prat:AddModuleToLoad(function()
 			subgroup = true,
 			showtargeticon = false,
 			showguild = false,
+			showfaction = false,
 			keep = false,
 			keeplots = false,
 			colormode = "CLASS",
@@ -333,6 +337,12 @@ Prat:AddModuleToLoad(function()
 				type = "toggle",
 				order = 143,
 			},
+			showfaction = {
+				name = PL["Show Faction"],
+				desc = PL["Toggle showing a faction indicator for your guild members."],
+				type = "toggle",
+				order = 144,
+			},
 			tabcomplete = {
 				name = PL["Enable TabComplete"],
 				desc = PL["Toggle tab completion of player names."],
@@ -413,7 +423,9 @@ Prat:AddModuleToLoad(function()
 		Prat.RegisterMessageItem("PLAYERLEVEL", "PREPLAYERDELIM", "before")
 		Prat.RegisterMessageItem("PLAYERGROUP", "POSTPLAYERDELIM", "after")
 		Prat.RegisterMessageItem("PLAYERCLIENTICON", "PLAYERLEVEL", "before")
-		Prat.RegisterMessageItem("PLAYERGUILD", "PREPLAYERDELIM", "before")
+		Prat.RegisterMessageItem("PLAYERFACTION", "PREPLAYERDELIM", "before")
+		Prat.RegisterMessageItem("PLAYERFACTIONDELIM", "PLAYERFACTION", "before")
+		Prat.RegisterMessageItem("PLAYERGUILD", "PLAYERFACTIONDELIM", "before")
 		Prat.RegisterMessageItem("PLAYERGUILDDELIM", "PLAYERGUILD", "before")
 
 		Prat.EnableProcessingForEvent("CHAT_MSG_GUILD_ACHIEVEMENT")
@@ -462,7 +474,8 @@ Prat:AddModuleToLoad(function()
 		module.Levels,
 		module.Classes,
 		module.Subgroups,
-		module.GuildMembers
+		module.GuildMembers,
+		module.GuildFactions
 	}
 
 	function module:EmptyDataCache()
@@ -595,6 +608,7 @@ Prat:AddModuleToLoad(function()
 
 	function module:GUILD_ROSTER_UPDATE()
 		wipe(self.GuildMembers)
+		wipe(self.GuildFactions)
 		for i = 1, GetNumGuildMembers() do
 			local Name, _, _, Level, _, _, _, _, _, _, Class = GetGuildRosterInfo(i)
 			if Name then
@@ -605,6 +619,24 @@ Prat:AddModuleToLoad(function()
 				end
 				self:addName(plr, nil, Class, Level, nil, "GUILD")
 				self:addName(plr, svr, Class, Level, nil, "GUILD")
+			end
+		end
+
+		-- Fetch faction data via Club API
+		local clubId = C_Club and C_Club.GetGuildClubId and C_Club.GetGuildClubId()
+		if clubId then
+			local members = C_Club.GetClubMembers(clubId)
+			if members then
+				for _, memberId in ipairs(members) do
+					local info = C_Club.GetMemberInfo(clubId, memberId)
+					if info and info.name and info.race then
+						local factionInfo = C_CreatureInfo.GetFactionInfo(info.race)
+						if factionInfo then
+							local name = Ambiguate(info.name, "all"):lower()
+							self.GuildFactions[name] = factionInfo.groupTag
+						end
+					end
+				end
 			end
 		end
 	end
@@ -848,11 +880,29 @@ Prat:AddModuleToLoad(function()
 			message.PREPLAYERDELIM = ":"
 		end
 
-		-- Add guild indicator if needed
-		if self.db.profile.showguild and self.GuildMembers[Name:lower()] then
+		-- Add guild and faction indicators if needed
+		-- Message item order: LEVEL : GUILDDELIM : GUILD : FACTIONDELIM : FACTION : PREDELIM : PLAYER
+		local nameLower = Name:lower()
+		local hasLevel = level and self.db.profile.level
+		local isGuildie = self.db.profile.showguild and self.GuildMembers[nameLower]
+		local faction = self.db.profile.showfaction and self.GuildFactions[nameLower]
+
+		if isGuildie then
 			message.PLAYERGUILD = CLR:Colorize("40ff40", "G")
 			message.PREPLAYERDELIM = ":"
-			if level and self.db.profile.level then
+			if hasLevel then
+				message.PLAYERGUILDDELIM = ":"
+			end
+		end
+
+		if faction then
+			local color = GetFactionColor(faction)
+			local letter = faction:sub(1, 1) -- "A" or "H"
+			message.PLAYERFACTION = color and color:WrapTextInColorCode(letter) or letter
+			message.PREPLAYERDELIM = ":"
+			if isGuildie then
+				message.PLAYERFACTIONDELIM = ":"
+			elseif hasLevel then
 				message.PLAYERGUILDDELIM = ":"
 			end
 		end

--- a/modules/PlayerNames.lua
+++ b/modules/PlayerNames.lua
@@ -59,8 +59,8 @@ Prat:AddModuleToLoad(function()
 		["Toggle raid group showing."] = true,
 		["Show Raid Target Icon"] = true,
 		["Toggle showing the raid target icon which is currently on the player."] = true,
-		["Show Guild"] = true,
-		["Toggle guild member showing."] = true,
+		["Mark Guildies"] = true,
+		["Toggle showing an indicator for your guild members."] = true,
 		["Use toon name for RealID"] = true,
 
 		-- In the high-cpu pullout
@@ -328,8 +328,8 @@ Prat:AddModuleToLoad(function()
 				hidden = Prat.IsRetail,
 			},
 			showguild = {
-				name = PL["Show Guild"],
-				desc = PL["Toggle guild member showing."],
+				name = PL["Mark Guildies"],
+				desc = PL["Toggle showing an indicator for your guild members."],
 				type = "toggle",
 				order = 143,
 			},


### PR DESCRIPTION
## Summary

- **PlayerNames: Mark Guildies** — New toggle that displays a green `G` indicator next to guild members' names in chat. Uses guild roster data from `GUILD_ROSTER_UPDATE`. Off by default.
- **PlayerNames: Show Faction** — New toggle that displays a colored `A` (Alliance) or `H` (Horde) next to guild members' names, using Blizzard's official faction colors via `GetFactionColor()`. Faction data resolved via `C_Club.GetMemberInfo` race data and `C_CreatureInfo.GetFactionInfo`, which works for offline and cross-server members. Off by default.
- **Achievements: Guild only grats** — New toggle that limits the "say grats" link to guild achievement events only. Grayed out when "Show grats link" is disabled. Off by default.

With all PlayerNames options enabled, names display as `60:G:H:PlayerName` (level, guild, faction, name). Each component can be toggled independently and all combinations produce correct output.

All options are opt-in and have no effect on existing behavior when disabled.

## Note on faction data

Currently, faction is only resolved for guild members via the Club API (`C_Club.GetMemberInfo` provides race, which maps to faction via `C_CreatureInfo.GetFactionInfo`). Ideally this would work for all players in chat, but we haven't found a reliable way to get faction for arbitrary non-guild players — `GetPlayerInfoByGUID` returns race for some players but not consistently for cross-server/offline ones. If there's a better API we're missing, happy to expand this.

## Testing

Only tested on WoW Midnight 12.0.1.66562 (retail). Not tested on Classic or other game versions this addon supports. The Club API usage for faction data is guarded with `C_Club and C_Club.GetGuildClubId` checks so it should degrade gracefully, but the faction feature may not work on older clients.

I'm kinda new to this addon so I'm not entirely sure how it normally works/behaves so hopefully this doesn't add any regressions that I don't notice!

Examples:
<img width="593" height="364" alt="image" src="https://github.com/user-attachments/assets/80d51011-d600-44ea-ac5d-2007650df30a" />
<img width="917" height="699" alt="image" src="https://github.com/user-attachments/assets/7371aaad-61fb-4cbd-ad40-ff872dadb3aa" />
<img width="832" height="348" alt="image" src="https://github.com/user-attachments/assets/a46831f8-33a4-4aa5-b12e-b55134fd495d" />