### PR TITLE
fix broken blue shaman with 1.15.9

### DIFF
--- a/services/classcolor.lua
+++ b/services/classcolor.lua
@@ -26,14 +26,14 @@ function private.GetClassColor(class, isLocal)
 		end
 	end
 
-	if C_ClassColor then
-		return C_ClassColor.GetClassColor(class) or defaultColor
-	end
+if CUSTOM_CLASS_COLORS and CUSTOM_CLASS_COLORS[class] then
+    local color = CUSTOM_CLASS_COLORS[class]
+    return CreateColor(color.r, color.g, color.b)
+end
 
-	if CUSTOM_CLASS_COLORS and CUSTOM_CLASS_COLORS[class] then
-		local color = CUSTOM_CLASS_COLORS[class]
-		return CreateColor(color.r, color.g, color.b)
-	end
+if C_ClassColor then
+    return C_ClassColor.GetClassColor(class) or defaultColor
+end
 
 	return RAID_CLASS_COLORS and RAID_CLASS_COLORS[class] or defaultColor
 end


### PR DESCRIPTION
with the new patch the color of shaman is broken when using "We Want Blue Shamans" addon and reseted to the original vanilla color like paladin. with this change, they will now blue again